### PR TITLE
Update README to add Docker Compose install step

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -85,6 +85,7 @@ You should now see a copy of the site running locally at http://localhost:3000/!
 == Running the notebook stack locally with Docker
 
 - install {Docker}[https://www.docker.com/products/overview]
+- install {Docker Compose}[https://docs.docker.com/compose/install]
 - clone this git repo
 - cd into the root of this repo, and then run
     docker-compose up


### PR DESCRIPTION
Changes proposed:

While setting up the project through Docker, Docker Compose needs to be installed separately after installation of Docker. So, added that as a step in the installation instructions.

@indentlabs/contributors
